### PR TITLE
Add req_options trait to BatchSpawnerBase class

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -99,6 +99,10 @@ class BatchSpawnerBase(Spawner):
         help="Length of time for submitted job to run"
         )
 
+    req_options = Unicode('', config=True, \
+        help="Other options to include into job submission script"
+        )
+
     req_username = Unicode()
     def _req_username_default(self):
         return self.user.name
@@ -365,6 +369,7 @@ class TorqueSpawner(BatchSpawnerRegexStates):
 #PBS -l mem={memory}
 #PBS -N jupyterhub-singleuser
 #PBS -v {keepvars}
+#PBS {options}
 
 {cmd}
 """,
@@ -407,6 +412,7 @@ class SlurmSpawner(BatchSpawnerRegexStates,UserEnvMixin):
 #SBATCH --export={keepvars}
 #SBATCH --uid={username}
 #SBATCH --get-user-env=L
+#SBATCH {options}
 
 which jupyterhub-singleuser
 {cmd}
@@ -438,7 +444,7 @@ class GridengineSpawner(BatchSpawnerBase):
 #$ -j yes
 #$ -N spawner-jupyterhub
 #$ -v {keepvars}
-#$ {user_options[args]}
+#$ {options}
 
 {cmd}
 """,
@@ -449,14 +455,6 @@ class GridengineSpawner(BatchSpawnerBase):
     # outputs job data XML string
     batch_query_cmd = Unicode('sudo -E -u {username} qstat -xml', config=True)
     batch_cancel_cmd = Unicode('sudo -E -u {username} qdel {job_id}', config=True)
-
-    options_form = """
-        <label for="args">Extra qsub arguments</label>
-        <input name="args" placeholder="e.g. -l gpu=4"></input>
-        """
-
-    def options_from_form(self, formdata):
-        return dict(args = formdata['args'][0])
 
     def parse_job_id(self, output):
         return output.split(' ')[2]


### PR DESCRIPTION
This allows to provide any submit script options not covered by common traits. `GridengineSpawner` is switched to use the trait instead of the options form, which is not available anyway when wrapped into
`ProfilesSpawner`. I have also made Torque and SLURM spawners to use the trait; I hope that's ok.

As a side note, the `ProfilesSpawner` works great! I like how it allows to preconfigure common spawner types. Here is configuration example I used with SGE:

```py
c.JupyterHub.spawner_class = 'batchspawner.ProfilesSpawner'
c.ProfilesSpawner.profiles = [
         ( "SGE Job - 1 GPU", 'sge_1gpu', 'batchspawner.GridengineSpawner', dict(req_options='-l gpu=1') ),
         ( "SGE Job - 2 GPU", 'sge_2gpu', 'batchspawner.GridengineSpawner', dict(req_options='-l gpu=2') ),
         ( "SGE Job - 3 GPU", 'sge_3gpu', 'batchspawner.GridengineSpawner', dict(req_options='-l gpu=3') ),
         ( "SGE Job - 4 GPU", 'sge_4gpu', 'batchspawner.GridengineSpawner', dict(req_options='-l gpu=4') ),
         ( "SGE Job - CPU",   'sge_cpu',  'batchspawner.GridengineSpawner', {} ),
         ( "Local server", 'local', 'jupyterhub.spawner.LocalProcessSpawner', {} ),
        ]
```